### PR TITLE
Fix pulse update on backend removal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ gorb
 .glide
 vendor
 .idea
+
+coverage.txt

--- a/core/context_test.go
+++ b/core/context_test.go
@@ -169,3 +169,27 @@ func TestPulseUpdateRemovesStashWhenBackendHasFullyRecovered(t *testing.T) {
 	assert.Empty(t, stash)
 	mockIpvs.AssertExpectations(t)
 }
+
+func TestPulseUpdateRemovesStashWhenBackendIsDeleted(t *testing.T) {
+	stash := map[pulse.ID]int32{pulse.ID{VsID: vsID, RsID: rsID}: int32(0)}
+	backends := make(map[string]*backend)
+	mockIpvs := &fakeIpvs{}
+
+	c := newRoutineContext(backends, mockIpvs)
+	c.processPulseUpdate(stash, pulse.Update{pulse.ID{VsID: vsID, RsID: rsID}, pulse.Metrics{}})
+
+	assert.Empty(t, stash)
+	mockIpvs.AssertExpectations(t)
+}
+
+func TestPulseUpdateRemovesStashWhenDeletedAfterNotification(t *testing.T) {
+	stash := map[pulse.ID]int32{pulse.ID{VsID: vsID, RsID: rsID}: int32(0)}
+	backends := map[string]*backend{rsID: &backend{service: &virtualService, options: &BackendOptions{}}}
+	mockIpvs := &fakeIpvs{}
+
+	c := newRoutineContext(backends, mockIpvs)
+	c.processPulseUpdate(stash, pulse.Update{pulse.ID{VsID: vsID, RsID: rsID}, pulse.Metrics{Status:pulse.StatusRemoved}})
+
+	assert.Empty(t, stash)
+	mockIpvs.AssertExpectations(t)
+}

--- a/pulse/pulse.go
+++ b/pulse/pulse.go
@@ -93,6 +93,7 @@ func (p *Pulse) Loop(id ID, pulseCh chan Update, consumerStopCh <-chan struct{})
 			}
 		case <-p.stopCh:
 			log.Infof("stopping pulse for %s", id)
+			pulseCh <- Update{id, p.metrics.Update(StatusRemoved)}
 			return
 		}
 

--- a/pulse/status.go
+++ b/pulse/status.go
@@ -32,6 +32,8 @@ const (
 	StatusUp StatusType = iota
 	// StatusDown means the backend is not responding to Pulse.
 	StatusDown
+	// StatusRemoved means the backend has been removed
+	StatusRemoved
 )
 
 func (status StatusType) String() string {
@@ -40,6 +42,8 @@ func (status StatusType) String() string {
 		return "Up"
 	case StatusDown:
 		return "Down"
+	case StatusRemoved:
+		return "Removed"
 	}
 
 	return "Unknown"


### PR DESCRIPTION
Remove the pulse info from the stash when a backend is removed.
This is to avoid the scenario where an unhealthy backend stored remains
unhealthy after being scaled down and up again.
In this case the pulse update had no effect as the removed backend was
still found in the stash.

Fix made in 2 commits to better visualise the actual change in behaviour