### PR TITLE
Allow generic ipvs scheduler flags

### DIFF
--- a/core/context.go
+++ b/core/context.go
@@ -41,6 +41,9 @@ var (
 	schedulerFlags = map[string]int{
 		"sh-fallback": gnl2go.IP_VS_SVC_F_SCHED_SH_FALLBACK,
 		"sh-port": gnl2go.IP_VS_SVC_F_SCHED_SH_PORT,
+		"flag-1": gnl2go.IP_VS_SVC_F_SCHED1,
+		"flag-2": gnl2go.IP_VS_SVC_F_SCHED2,
+		"flag-3": gnl2go.IP_VS_SVC_F_SCHED3,
 	}
 	ErrIpvsSyscallFailed = errors.New("error while calling into IPVS")
 	ErrObjectExists = errors.New("specified object already exists")

--- a/core/context_test.go
+++ b/core/context_test.go
@@ -103,13 +103,29 @@ func TestServiceIsCreated(t *testing.T) {
 	mockDisco.AssertExpectations(t)
 }
 
-func TestServiceIsCreatedWithCustomFlags(t *testing.T) {
+func TestServiceIsCreatedWithShFlags(t *testing.T) {
 	options := &ServiceOptions{Port: 80, Host: "localhost", Protocol: "tcp", Method: "sh", Flags: "sh-port|sh-fallback"}
 	mockIpvs := &fakeIpvs{}
 	mockDisco := &fakeDisco{}
 	c := newContext(mockIpvs, mockDisco)
 
 	mockIpvs.On("AddServiceWithFlags", "127.0.0.1", uint16(80), uint16(syscall.IPPROTO_TCP), "sh", gnl2go.U32ToBinFlags(gnl2go.IP_VS_SVC_F_SCHED_SH_FALLBACK|gnl2go.IP_VS_SVC_F_SCHED_SH_PORT)).Return(nil)
+	mockDisco.On("Expose", virtualServiceId, "127.0.0.1", uint16(80)).Return(nil)
+
+	err := c.createService(virtualServiceId, options)
+	assert.NoError(t, err)
+	mockIpvs.AssertExpectations(t)
+	mockDisco.AssertExpectations(t)
+}
+
+func TestServiceIsCreatedWithGenericCustomFlags(t *testing.T) {
+	options := &ServiceOptions{Port: 80, Host: "localhost", Protocol: "tcp", Method: "sh", Flags: "flag-1|flag-2|flag-3"}
+	mockIpvs := &fakeIpvs{}
+	mockDisco := &fakeDisco{}
+	c := newContext(mockIpvs, mockDisco)
+
+	mockIpvs.On("AddServiceWithFlags", "127.0.0.1", uint16(80), uint16(syscall.IPPROTO_TCP), "sh",
+		gnl2go.U32ToBinFlags(gnl2go.IP_VS_SVC_F_SCHED1 | gnl2go.IP_VS_SVC_F_SCHED2 | gnl2go.IP_VS_SVC_F_SCHED3)).Return(nil)
 	mockDisco.On("Expose", virtualServiceId, "127.0.0.1", uint16(80)).Return(nil)
 
 	err := c.createService(virtualServiceId, options)


### PR DESCRIPTION
ipvs/ipvsadm support the generic flags 'flag-1', 'flag-2', and 'flag-3'
for custom schedulers. Currently gorb rejects those flags as invalid.
This patch changes gorb to allow those flags.