### PR TITLE
Add PATCH endpoint for virtual services

### DIFF
--- a/core/context.go
+++ b/core/context.go
@@ -58,7 +58,7 @@ type backend struct {
 
 // Context abstacts away the underlying IPVS bindings implementation.
 type Context struct {
-	ipvs         IPVS
+	ipvs         ipvs_shim.IPVS
 	endpoint     net.IP
 	services     map[string]*service
 	backends     map[string]*backend
@@ -68,16 +68,6 @@ type Context struct {
 	stopCh       chan struct{}
 	vipInterface netlink.Link
 	store        *Store
-}
-
-type IPVS interface {
-	Init() error
-	Flush() error
-	AddService(vip string, port uint16, protocol uint16, sched string, flags []string) error
-	DelService(vip string, port uint16, protocol uint16) error
-	AddDestPort(vip string, vport uint16, rip string, rport uint16, protocol uint16, weight uint32, fwd string) error
-	UpdateDestPort(vip string, vport uint16, rip string, rport uint16, protocol uint16, weight uint32, fwd string) error
-	DelDestPort(vip string, vport uint16, rip string, rport uint16, protocol uint16) error
 }
 
 // NewContext creates a new Context and initializes IPVS.
@@ -162,7 +152,7 @@ func (ctx *Context) Close() {
 
 // CreateService registers a new virtual service with IPVS.
 func (ctx *Context) createService(vsID string, opts *ServiceOptions) error {
-	if err := opts.Validate(ctx.endpoint); err != nil {
+	if err := opts.Fill(ctx.endpoint); err != nil {
 		return err
 	}
 
@@ -220,9 +210,69 @@ func (ctx *Context) CreateService(vsID string, opts *ServiceOptions) error {
 	return ctx.createService(vsID, opts)
 }
 
+// updateService updates a virtual service in IPVS.
+func (ctx *Context) updateService(vsID string, opts *ServiceOptions) error {
+	if err := opts.Fill(ctx.endpoint); err != nil {
+		return err
+	}
+
+	var old *service
+	old, exists := ctx.services[vsID]
+	if !exists {
+		log.Infof("attempted to update a non-existent service [%s], will create instead", vsID)
+		return ctx.createService(vsID, opts)
+	}
+
+	// Check if not possible to update.
+	if old.options.host.String() != opts.host.String() ||
+		old.options.Port != opts.Port ||
+		old.options.Protocol != opts.Protocol {
+		log.Info("unable to update virtual service due to host/port/protocol changing, must recreate")
+		if _, err := ctx.removeService(vsID); err != nil {
+			return err
+		}
+		return ctx.createService(vsID, opts)
+	}
+
+	log.Infof("updating virtual service [%s] on %s:%d", vsID, opts.host,
+		opts.Port)
+
+	// update service in external store
+	if ctx.store != nil {
+		if err := ctx.store.UpdateService(vsID, opts); err != nil {
+			log.Errorf("error while updating service : %s", err)
+			return err
+		}
+	}
+
+	var flags []string
+	if len(opts.Flags) > 0 {
+		flags = strings.Split(opts.Flags, "|")
+	}
+	if err := ctx.ipvs.UpdateService(opts.host.String(), opts.Port, opts.protocol, opts.Method, flags); err != nil {
+		log.Errorf("error while updating virtual service: %s", err)
+		return ErrIpvsSyscallFailed
+	}
+
+	ctx.services[vsID] = &service{options: opts}
+
+	if err := ctx.disco.Expose(vsID, opts.host.String(), opts.Port); err != nil {
+		log.Errorf("error while exposing service to Disco: %s", err)
+	}
+
+	return nil
+}
+
+// CreateService registers a new virtual service with IPVS.
+func (ctx *Context) UpdateService(vsID string, opts *ServiceOptions) error {
+	ctx.mutex.Lock()
+	defer ctx.mutex.Unlock()
+	return ctx.updateService(vsID, opts)
+}
+
 // CreateBackend registers a new backend with a virtual service.
 func (ctx *Context) createBackend(vsID, rsID string, opts *BackendOptions) error {
-	if err := opts.SetDefaults(); err != nil {
+	if err := opts.Fill(); err != nil {
 		return err
 	}
 	p, err := pulse.New(opts.host.String(), opts.Port, opts.Pulse)

--- a/core/context.go
+++ b/core/context.go
@@ -189,7 +189,7 @@ func (ctx *Context) createService(vsID string, opts *ServiceOptions) error {
 	if len(opts.Flags) > 0 {
 		flags = strings.Split(opts.Flags, "|")
 	}
-	if err := ctx.ipvs.AddService(opts.host.String(), opts.Port, opts.protocol, opts.Method, flags); err != nil {
+	if err := ctx.ipvs.AddService(opts.host.String(), opts.Port, opts.Protocol, opts.Method, flags); err != nil {
 		log.Errorf("error while creating virtual service: %s", err)
 		return ErrIpvsSyscallFailed
 	}
@@ -249,7 +249,7 @@ func (ctx *Context) updateService(vsID string, opts *ServiceOptions) error {
 	if len(opts.Flags) > 0 {
 		flags = strings.Split(opts.Flags, "|")
 	}
-	if err := ctx.ipvs.UpdateService(opts.host.String(), opts.Port, opts.protocol, opts.Method, flags); err != nil {
+	if err := ctx.ipvs.UpdateService(opts.host.String(), opts.Port, opts.Protocol, opts.Method, flags); err != nil {
 		log.Errorf("error while updating virtual service: %s", err)
 		return ErrIpvsSyscallFailed
 	}
@@ -313,7 +313,7 @@ func (ctx *Context) createBackend(vsID, rsID string, opts *BackendOptions) error
 		vs.options.Port,
 		opts.host.String(),
 		opts.Port,
-		vs.options.protocol,
+		vs.options.Protocol,
 		opts.Weight,
 		opts.Method,
 	); err != nil {
@@ -352,7 +352,7 @@ func (ctx *Context) updateBackend(vsID, rsID string, weight uint32) (uint32, err
 		rs.service.options.Port,
 		rs.options.host.String(),
 		rs.options.Port,
-		rs.service.options.protocol,
+		rs.service.options.Protocol,
 		weight,
 		rs.options.Method,
 	); err != nil {
@@ -413,7 +413,7 @@ func (ctx *Context) removeService(vsID string) (*ServiceOptions, error) {
 	if err := ctx.ipvs.DelService(
 		vs.options.host.String(),
 		vs.options.Port,
-		vs.options.protocol,
+		vs.options.Protocol,
 	); err != nil {
 		log.Errorf("error while removing virtual service [%s]", vsID)
 		return nil, ErrIpvsSyscallFailed
@@ -484,7 +484,7 @@ func (ctx *Context) removeBackend(vsID, rsID string) (*BackendOptions, error) {
 		rs.service.options.Port,
 		rs.options.host.String(),
 		rs.options.Port,
-		rs.service.options.protocol,
+		rs.service.options.Protocol,
 	); err != nil {
 		log.Errorf("error while removing backend [%s/%s]", vsID, rsID)
 		return nil, ErrIpvsSyscallFailed

--- a/core/context.go
+++ b/core/context.go
@@ -216,7 +216,6 @@ func (ctx *Context) updateService(vsID string, opts *ServiceOptions) error {
 		return err
 	}
 
-	var old *service
 	old, exists := ctx.services[vsID]
 	if !exists {
 		log.Infof("attempted to update a non-existent service [%s], will create instead", vsID)

--- a/core/options.go
+++ b/core/options.go
@@ -64,8 +64,8 @@ type ServiceOptions struct {
 	protocol uint16
 }
 
-// Validate fills missing fields and validates virtual service configuration.
-func (o *ServiceOptions) Validate(defaultHost net.IP) error {
+// Fill missing fields and validates virtual service configuration.
+func (o *ServiceOptions) Fill(defaultHost net.IP) error {
 	if o.Port == 0 {
 		return ErrMissingEndpoint
 	}
@@ -148,8 +148,8 @@ type BackendOptions struct {
 	host net.IP
 }
 
-// SetDefaults fills missing fields and validates backend configuration.
-func (o *BackendOptions) SetDefaults() error {
+// Fill missing fields and validates backend configuration.
+func (o *BackendOptions) Fill() error {
 	if len(o.Host) == 0 || o.Port == 0 {
 		return ErrMissingEndpoint
 	}

--- a/core/options_test.go
+++ b/core/options_test.go
@@ -1,6 +1,5 @@
 package core
 
-
 import (
 	"testing"
 
@@ -9,21 +8,21 @@ import (
 
 func TestValidateAcceptsAllowedServiceOptionsFlags(t *testing.T) {
 	options := ServiceOptions{Port: 80, Host: "localhost", Protocol: "tcp", Method: "dr", Flags: "sh-port|sh-fallback"}
-	err := options.Validate(nil)
+	err := options.Fill(nil)
 
 	assert.NoError(t, err)
 }
 
 func TestValidateRejectsInvalidServiceOptionsFlags(t *testing.T) {
 	options := ServiceOptions{Port: 80, Host: "localhost", Protocol: "tcp", Method: "dr", Flags: "sh-port|does-not-match"}
-	err := options.Validate(nil)
+	err := options.Fill(nil)
 
 	assert.EqualError(t, err, "specified flag is unknown")
 }
 
 func TestValidateAcceptsNoFlags(t *testing.T) {
 	options := ServiceOptions{Port: 80, Host: "localhost", Protocol: "tcp", Method: "dr"}
-	err := options.Validate(nil)
+	err := options.Fill(nil)
 
 	assert.NoError(t, err)
 }

--- a/core/store.go
+++ b/core/store.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"encoding/json"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/libkv"
 	"github.com/docker/libkv/store"
@@ -164,6 +165,15 @@ func (s *Store) Close() {
 func (s *Store) CreateService(vsID string, opts *ServiceOptions) error {
 	// put to store
 	if err := s.put(s.storeServicePath+"/"+vsID, opts, false); err != nil {
+		log.Errorf("error while put service to store: %s", err)
+		return err
+	}
+	return nil
+}
+
+func (s *Store) UpdateService(vsID string, opts *ServiceOptions) error {
+	// put to store
+	if err := s.put(s.storeServicePath+"/"+vsID, opts, true); err != nil {
 		log.Errorf("error while put service to store: %s", err)
 		return err
 	}

--- a/core/store_test.go
+++ b/core/store_test.go
@@ -3,15 +3,20 @@ package core
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"encoding/json"
+
 	"github.com/docker/libkv"
-	libkvmock "github.com/docker/libkv/store/mock"
 	"github.com/docker/libkv/store"
+	libkvmock "github.com/docker/libkv/store/mock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 type storeMock struct {
 	libkvmock.Mock
 }
+
+var storeURLs = []string{"mock://127.0.0.1:2000", "mock://127.0.0.2:2001", "mock://127.0.0.3:2002"}
 
 func (s *storeMock) mockNew() func(endpoints []string, options *store.Config) (store.Store, error) {
 	return func(endpoints []string, options *store.Config) (store.Store, error) {
@@ -27,7 +32,6 @@ func TestMultipleURLs(t *testing.T) {
 	libkv.AddStore("mock", m.mockNew())
 	m.On("List", "/").Return([]*store.KVPair{}, nil)
 
-	storeURLs := []string{"mock://127.0.0.1:2000", "mock://127.0.0.2:2001", "mock://127.0.0.3:2002"}
 	store, err := NewStore(storeURLs, "/", "/", 60, &Context{})
 
 	assert.NoError(err)
@@ -58,4 +62,28 @@ func TestErrorIfPathMismatch(t *testing.T) {
 	_, err := NewStore(storeURLs, "/", "/", 60, &Context{})
 
 	assert.Error(err)
+}
+
+func TestUpdateService(t *testing.T) {
+	m := storeMock{}
+	libkv.AddStore("mock", m.mockNew())
+
+	vsID := "my-virtual-server"
+	opts := &ServiceOptions{
+		Host:       "10.10.0.0",
+		Port:       8080,
+		Protocol:   "tcp",
+		Method:     "sh",
+		Flags:      "flag-1|flag-2",
+		Persistent: false,
+	}
+	optsBytes, _ := json.Marshal(opts)
+	m.On("List", "").Return([]*store.KVPair{}, nil)
+	m.On("Exists", "/"+vsID).Return(false, nil)
+	m.On("Put", "/"+vsID, optsBytes, mock.Anything).Return(nil)
+
+	store, _ := NewStore(storeURLs, "", "", 60, &Context{})
+	store.UpdateService(vsID, opts)
+
+	m.AssertExpectations(t)
 }

--- a/http.go
+++ b/http.go
@@ -75,6 +75,23 @@ func (h serviceCreateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	}
 }
 
+type serviceUpdateHandler struct {
+	ctx *core.Context
+}
+
+func (h serviceUpdateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	var (
+		opts core.ServiceOptions
+		vars = mux.Vars(r)
+	)
+
+	if err := json.NewDecoder(r.Body).Decode(&opts); err != nil {
+		writeError(w, err)
+	} else if err := h.ctx.UpdateService(vars["vsID"], &opts); err != nil {
+		writeError(w, err)
+	}
+}
+
 type backendCreateHandler struct {
 	ctx *core.Context
 }

--- a/ipvs-shim/ipvs_shim.go
+++ b/ipvs-shim/ipvs_shim.go
@@ -96,7 +96,7 @@ func createFlagbits(flags []string) uint32 {
 	for _, flag := range flags {
 		if b, exists := schedulerFlags[flag]; exists {
 			// libipvs incorrectly repacks flags as big endian. This is a hack to ensure the flag bytes get passed
-			// correctly. It assumes the scheduler flags all fit into a single byte (which they do).
+			// correctly. Remove the shift once https://github.com/mqliang/libipvs/pull/8 is merged.
 			flagbits |= b << 24
 		} else {
 			log.Warnf("Unknown scheduler flag %q, ignoring", flag)

--- a/ipvs-shim/ipvs_shim_test.go
+++ b/ipvs-shim/ipvs_shim_test.go
@@ -15,12 +15,12 @@ func TestCreateFlagbits(t *testing.T) {
 		{
 			"multiple flags",
 			[]string{"flag-1", "flag-2"},
-			libipvs.IP_VS_SVC_F_SCHED1 | libipvs.IP_VS_SVC_F_SCHED2,
+			(libipvs.IP_VS_SVC_F_SCHED1 | libipvs.IP_VS_SVC_F_SCHED2) << 24,
 		},
 		{
 			"invalid flags",
 			[]string{"flag-1", "invalid-ignored", "flag-2"},
-			libipvs.IP_VS_SVC_F_SCHED1 | libipvs.IP_VS_SVC_F_SCHED2,
+			(libipvs.IP_VS_SVC_F_SCHED1 | libipvs.IP_VS_SVC_F_SCHED2) << 24,
 		},
 	}
 	for _, tt := range tests {

--- a/main.go
+++ b/main.go
@@ -32,21 +32,22 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/gorilla/mux"
 
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"strings"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 var (
 	// Version get dynamically set to git rev by ldflags at build time
-	Version          = "DEV"
+	Version = "DEV"
 
-	debug            = flag.Bool("v", false, "enable verbose output")
-	device           = flag.String("i", "eth0", "default interface to bind services on")
-	flush            = flag.Bool("f", false, "flush IPVS pools on start")
-	listen           = flag.String("l", ":4672", "endpoint to listen for HTTP requests")
-	consul           = flag.String("c", "", "URL for Consul HTTP API")
-	vipInterface     = flag.String("vipi", "", "interface to add VIPs")
-	storeURLs        = flag.String("store", "", "comma delimited list of store urls for sync data. All urls must have" +
+	debug        = flag.Bool("v", false, "enable verbose output")
+	device       = flag.String("i", "eth0", "default interface to bind services on")
+	flush        = flag.Bool("f", false, "flush IPVS pools on start")
+	listen       = flag.String("l", ":4672", "endpoint to listen for HTTP requests")
+	consul       = flag.String("c", "", "URL for Consul HTTP API")
+	vipInterface = flag.String("vipi", "", "interface to add VIPs")
+	storeURLs    = flag.String("store", "", "comma delimited list of store urls for sync data. All urls must have"+
 		" identical schemes and paths.")
 	storeTimeout     = flag.Int64("store-sync-time", 60, "sync-time for store")
 	storeServicePath = flag.String("store-service-path", "services", "store service path")
@@ -83,11 +84,11 @@ func main() {
 	}
 
 	ctx, err := core.NewContext(core.ContextOptions{
-		Disco:            *consul,
-		Endpoints:        hostIPs,
-		Flush:            *flush,
-		ListenPort:       listenPort,
-		VipInterface:     *vipInterface})
+		Disco:        *consul,
+		Endpoints:    hostIPs,
+		Flush:        *flush,
+		ListenPort:   listenPort,
+		VipInterface: *vipInterface})
 
 	if err != nil {
 		log.Fatalf("error while initializing server context: %s", err)
@@ -111,6 +112,7 @@ func main() {
 
 	r.Handle("/service/{vsID}", serviceCreateHandler{ctx}).Methods("PUT")
 	r.Handle("/service/{vsID}/{rsID}", backendCreateHandler{ctx}).Methods("PUT")
+	r.Handle("/service/{vsID}", serviceUpdateHandler{ctx}).Methods("PATCH")
 	r.Handle("/service/{vsID}/{rsID}", backendUpdateHandler{ctx}).Methods("PATCH")
 	r.Handle("/service/{vsID}", serviceRemoveHandler{ctx}).Methods("DELETE")
 	r.Handle("/service/{vsID}/{rsID}", backendRemoveHandler{ctx}).Methods("DELETE")


### PR DESCRIPTION
Requires the same parameters as PUT, and updates the existing service in
place. If the service doesn't exist, it will create it. This allows
automation to just send a PATCH always.