### PR TITLE
Fail if attempt to PATCH new ip/port/protocol

### DIFF
--- a/core/context.go
+++ b/core/context.go
@@ -226,7 +226,7 @@ func (ctx *Context) updateService(vsID string, opts *ServiceOptions) error {
 	if old.options.host.String() != opts.host.String() ||
 		old.options.Port != opts.Port ||
 		old.options.Protocol != opts.Protocol {
-		return fmt.Errorf("unable to update virtual service due to host/port/protocol changing, remove it first")
+		return fmt.Errorf("unable to update virtual service [%s] due to host/port/protocol changing", vsID)
 	}
 
 	log.Infof("updating virtual service [%s] on %s:%d", vsID, opts.host,

--- a/core/context.go
+++ b/core/context.go
@@ -226,11 +226,7 @@ func (ctx *Context) updateService(vsID string, opts *ServiceOptions) error {
 	if old.options.host.String() != opts.host.String() ||
 		old.options.Port != opts.Port ||
 		old.options.Protocol != opts.Protocol {
-		log.Info("unable to update virtual service due to host/port/protocol changing, must recreate")
-		if _, err := ctx.removeService(vsID); err != nil {
-			return err
-		}
-		return ctx.createService(vsID, opts)
+		return fmt.Errorf("unable to update virtual service due to host/port/protocol changing, remove it first")
 	}
 
 	log.Infof("updating virtual service [%s] on %s:%d", vsID, opts.host,

--- a/core/context_test.go
+++ b/core/context_test.go
@@ -164,7 +164,7 @@ func TestServiceIsUpdated(t *testing.T) {
 	mockDisco.AssertExpectations(t)
 }
 
-func TestServiceIsRecreatedIfHostPortProtocolChange(t *testing.T) {
+func TestCannotUpdateServiceIfHostPortProtocolChange(t *testing.T) {
 	tests := []struct {
 		name    string
 		updated *ServiceOptions
@@ -191,17 +191,12 @@ func TestServiceIsRecreatedIfHostPortProtocolChange(t *testing.T) {
 
 			mockIpvs.On("AddService", options.Host, options.Port, options.Protocol, options.Method,
 				[]string{options.Flags}).Return(nil)
-			mockIpvs.On("DelService", options.Host, options.Port, options.Protocol).Return(nil)
-			mockIpvs.On("AddService", tt.updated.Host, tt.updated.Port, tt.updated.Protocol,
-				tt.updated.Method, []string{tt.updated.Flags}).Return(nil)
 			mockDisco.On("Expose", vsID, options.Host, options.Port).Return(nil)
-			mockDisco.On("Remove", vsID).Return(nil)
-			mockDisco.On("Expose", vsID, tt.updated.Host, tt.updated.Port).Return(nil)
 
 			err := c.createService(vsID, options)
 			assert.NoError(t, err)
 			err = c.updateService(vsID, tt.updated)
-			assert.NoError(t, err)
+			assert.Error(t, err)
 
 			mockIpvs.AssertExpectations(t)
 			mockDisco.AssertExpectations(t)


### PR DESCRIPTION
We shouldn't recreate the service on a PATCH as this could be extremely
disruptive, and is most likely unintentional from the user.